### PR TITLE
Fix optional start_buckets handling

### DIFF
--- a/node-red-contrib-artnet-controller.js
+++ b/node-red-contrib-artnet-controller.js
@@ -721,10 +721,11 @@ module.exports = function (RED) {
                         payload.buckets = [{"channel": payload.channel, "value": payload.value}];
                     } 
                     if (Array.isArray(payload.buckets)) {
+                        const startBuckets = Array.isArray(payload.start_buckets) ? payload.start_buckets : [];
                         this.debug(`[input] add transitions "${transition}" for some buckets`);
                         for (i = 0; i < payload.buckets.length; i++) {
                             this.clearTransition(payload.buckets[i].channel, false);
-                            let startValue = payload.start_buckets.find(({ channel }) => channel === payload.buckets[i].channel);
+                            let startValue = startBuckets.find(({ channel }) => channel === payload.buckets[i].channel);
                             if (typeof startValue !== 'undefined') startValue = startValue.value;   // try to fetch the value
                             if (typeof startValue === 'undefined') startValue = this.get(payload.buckets[i].channel);   // last hope to set the actual old value
                             this.addTransition(payload.buckets[i].channel, transition, startValue, payload.buckets[i].value,


### PR DESCRIPTION
Hello! Thank you for continuous improvements! I upgraded to 0.2.0 today.

The README still mentions `start_buckets` as optional but after upgrading to 0.2.0, the ArtNet out node throws an error because they are not.

Possibly introduced in https://github.com/Bannsaenger/node-red-contrib-artnet-controller/commit/a0f369508e9bce5d08adf591281e7c8c3ea3a437#diff-2bb39971a0b23c1dd4e292654f05a60428d59ce4ad4c69cbbd750f8ffd27f53dL248-R715